### PR TITLE
Removing match case syntax

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10
     - name: Install dependencies

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,9 +5,9 @@ name: Pytest
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, openapi-bindings ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, openapi-bindings ]
 
 jobs:
   build:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: gcp-runner
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,7 +1,7 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Pytest
+env:
+  API_HOST: ${{ vars.API_HOST }}
+  API_KEY: ${{ secrets.API_KEY }}
 
 on:
   push:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        pytest workflow_tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest~=4.6.7 # needed for python 2.7+3.4
+pytest~=7.1.2
 pytest-cov>=2.8.1
 pytest-randomly==1.2.3 # needed for python 2.7+3.4
 python-dotenv==1.0.1

--- a/test/test_get_lilt_create_content_response.py
+++ b/test/test_get_lilt_create_content_response.py
@@ -40,12 +40,12 @@ class TestGetLiltCreateContentResponse(unittest.TestCase):
                     lilt.models.lilt_create_content.LiltCreateContent(
                         language = '0', 
                         template = '0', 
-                        template_params = lilt.models.lilt_create_content_template_params.LiltCreateContent_templateParams(
+                        template_params = lilt.models.lilt_create_content_template_params.LiltCreateContentTemplateParams(
                             content_length = 56, 
                             language = '0', 
                             sections = '0', 
                             summary = '0', ), 
-                        preferences = lilt.models.lilt_create_content_preferences.LiltCreateContent_preferences(
+                        preferences = lilt.models.lilt_create_content_preferences.LiltCreateContentPreferences(
                             tone = '0', 
                             styleguide = '0', ), )
                     ]

--- a/test/test_lilt_create_content.py
+++ b/test/test_lilt_create_content.py
@@ -38,12 +38,12 @@ class TestLiltCreateContent(unittest.TestCase):
             return LiltCreateContent(
                 language = '0', 
                 template = '0', 
-                template_params = lilt.models.lilt_create_content_template_params.LiltCreateContent_templateParams(
+                template_params = lilt.models.lilt_create_content_template_params.LiltCreateContentTemplateParams(
                     content_length = 56, 
                     language = '0', 
                     sections = '0', 
                     summary = '0', ), 
-                preferences = lilt.models.lilt_create_content_preferences.LiltCreateContent_preferences(
+                preferences = lilt.models.lilt_create_content_preferences.LiltCreateContentPreferences(
                     tone = '0', 
                     styleguide = '0', )
             )
@@ -51,7 +51,7 @@ class TestLiltCreateContent(unittest.TestCase):
             return LiltCreateContent(
                 language = '0',
                 template = '0',
-                template_params = lilt.models.lilt_create_content_template_params.LiltCreateContent_templateParams(
+                template_params = lilt.models.lilt_create_content_template_params.LiltCreateContentTemplateParams(
                     content_length = 56, 
                     language = '0', 
                     sections = '0', 

--- a/workflow_tests/test_create_content.py
+++ b/workflow_tests/test_create_content.py
@@ -40,167 +40,172 @@ generate_content_sections_cases = [
 
 
 def get_sign(sign_case):
-    if sign_case == "none":
-        return None
-    elif sign_case == "unsigned":
-        return False
-    elif sign_case == "signed":
-        return True
-    elif sign_case == "non_boolean_1":
-        return 1
-    elif sign_case == "non_boolean_0":
-        return 0
+    match sign_case:
+        case "none":
+            return None
+        case "unsigned":
+            return False
+        case "signed":
+            return True
+        case "non_boolean_1":
+            return 1
+        case "non_boolean_0":
+            return 0
 
 
 def get_summary(char_case):
-    if char_case == "none":
-        return ""
-    elif char_case == "normal":
-        return "a blog post about how important bees are to my honey farm"
-    elif char_case == "over500":
-        return "a blog post about how important bees are to my honey farm" * 10
-    elif char_case == "non_string":
-        return 1
+    match char_case:
+        case "none":
+            return ""
+        case "normal":
+            return "a blog post about how important bees are to my honey farm"
+        case "over500":
+            return "a blog post about how important bees are to my honey farm" * 10
+        case "non_string":
+            return 1
 
 
 def get_section(section_case):
-    if section_case == "none":
-        return []
-    elif section_case == "one":
-        return ["Bees and me"]
-    elif section_case == "multiple":
-        return ["Bees and me", "Honey for you", "Conclusion"]
-    elif section_case == "non_list":
-        return 1
-    elif section_case == "non_string_elements":
-        return [1, 2]
+    match section_case:
+        case "none":
+            return []
+        case "one":
+            return ["Bees and me"]
+        case "multiple":
+            return ["Bees and me", "Honey for you", "Conclusion"]
+        case "non_list":
+            return 1
+        case "non_string_elements":
+            return [1, 2]
 
 
 def expected_chars(char_case):
-    if char_case == "none":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+    match char_case:
+        case "none":
+            return {
                 "language": "en-US",
-                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                "summary": ""
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "summary": ""
+                }
             }
-        }
-    elif char_case == "normal":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+        case "normal":
+            return {
                 "language": "en-US",
-                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                "summary": "a blog post about how important bees are to my honey farm"
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "summary": "a blog post about how important bees are to my honey farm"
+                }
             }
-        }
-    elif char_case == "over500":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+        case "over500":
+            return {
                 "language": "en-US",
-                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                "summary": 'a blog post about how important bees are to '
-                            'my honey farma blog post about how important '
-                            'bees are to my honey farma blog post about '
-                            'how important bees are to my honey farma blog '
-                            'post about how important bees are to my honey '
-                            'farma blog post about how important bees are '
-                            'to my honey farma blog post about how '
-                            'important bees are to my honey farma blog '
-                            'post about how important bees are to my honey '
-                            'farma blog post about how important bees are '
-                            'to my honey farma blog post about how '
-                            'important bees are to my honey farma blog '
-                            'post about how important bees are to my honey '
-                            'farm'
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "summary": 'a blog post about how important bees are to '
+                                'my honey farma blog post about how important '
+                                'bees are to my honey farma blog post about '
+                                'how important bees are to my honey farma blog '
+                                'post about how important bees are to my honey '
+                                'farma blog post about how important bees are '
+                                'to my honey farma blog post about how '
+                                'important bees are to my honey farma blog '
+                                'post about how important bees are to my honey '
+                                'farma blog post about how important bees are '
+                                'to my honey farma blog post about how '
+                                'important bees are to my honey farma blog '
+                                'post about how important bees are to my honey '
+                                'farm'
+                }
             }
-        }
-    elif char_case == "non_string":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+        case "non_string":
+            return {
                 "language": "en-US",
-                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                "summary": "1"
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "summary": "1"
+                }
             }
-        }
 
 
 def expected_section(section_case):
-    if section_case == "none":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+    match section_case:
+        case "none":
+            return {
                 "language": "en-US",
-                "sections": "[]",
-                "summary": "a blog post about how important bees are to my honey farm"
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "[]",
+                    "summary": "a blog post about how important bees are to my honey farm"
+                }
             }
-        }
-    elif section_case == "one":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+        case "one":
+            return {
                 "language": "en-US",
-                "sections": "['Bees and me']",
-                "summary": "a blog post about how important bees are to my honey farm"
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "['Bees and me']",
+                    "summary": "a blog post about how important bees are to my honey farm"
+                }
             }
-        }
-    elif section_case == "multiple":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+        case "multiple":
+            return {
                 "language": "en-US",
-                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                "summary": "a blog post about how important bees are to my honey farm"
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "summary": "a blog post about how important bees are to my honey farm"
+                }
             }
-        }
-    elif section_case == "non_list":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+        case "non_list":
+            return {
                 "language": "en-US",
-                "sections": "1",
-                "summary": "a blog post about how important bees are to my honey farm"
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "1",
+                    "summary": "a blog post about how important bees are to my honey farm"
+                }
             }
-        }
-    elif section_case == "non_string_elements":
-        return {
-            "language": "en-US",
-            "preferences": None,
-            "template": "blog-post",
-            "template_params": {
-                "content_length": 1000,
+        case "non_string_elements":
+            return {
                 "language": "en-US",
-                "sections": "[1, 2]",
-                "summary": "a blog post about how important bees are to my honey farm"
+                "preferences": None,
+                "template": "blog-post",
+                "template_params": {
+                    "content_length": 1000,
+                    "language": "en-US",
+                    "sections": "[1, 2]",
+                    "summary": "a blog post about how important bees are to my honey farm"
+                }
             }
-        }
 
 
 def assert_response(create_content_obj, expected):

--- a/workflow_tests/test_create_content.py
+++ b/workflow_tests/test_create_content.py
@@ -89,7 +89,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
                     "summary": ""
                 }
             }
@@ -101,7 +101,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -113,7 +113,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
                     "summary": 'a blog post about how important bees are to '
                                 'my honey farma blog post about how important '
                                 'bees are to my honey farma blog post about '
@@ -138,7 +138,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
                     "summary": "1"
                 }
             }
@@ -154,7 +154,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "[]",
+                    "sections": [],
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -166,7 +166,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "['Bees and me']",
+                    "sections": ["Bees and me"],
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -178,7 +178,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -202,7 +202,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": "[1, 2]",
+                    "sections": [1, 2],
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }

--- a/workflow_tests/test_create_content.py
+++ b/workflow_tests/test_create_content.py
@@ -89,7 +89,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
                     "summary": ""
                 }
             }
@@ -101,7 +101,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -113,7 +113,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
                     "summary": 'a blog post about how important bees are to '
                                 'my honey farma blog post about how important '
                                 'bees are to my honey farma blog post about '
@@ -138,7 +138,7 @@ def expected_chars(char_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
                     "summary": "1"
                 }
             }
@@ -154,7 +154,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": [],
+                    "sections": "[]",
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -166,7 +166,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": ["Bees and me"],
+                    "sections": "['Bees and me']",
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -178,7 +178,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": ["Bees and me", "Honey for you", "Conclusion"],
+                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }
@@ -202,7 +202,7 @@ def expected_section(section_case):
                 "template_params": {
                     "content_length": 1000,
                     "language": "en-US",
-                    "sections": [1, 2],
+                    "sections": "[1, 2]",
                     "summary": "a blog post about how important bees are to my honey farm"
                 }
             }

--- a/workflow_tests/test_create_content.py
+++ b/workflow_tests/test_create_content.py
@@ -1,9 +1,12 @@
 from __future__ import print_function
+from dotenv import load_dotenv
 
 import os
 import pytest
 import time
 import lilt
+
+load_dotenv()
 
 configuration = lilt.Configuration(
     host=os.environ["API_HOST"],
@@ -37,172 +40,167 @@ generate_content_sections_cases = [
 
 
 def get_sign(sign_case):
-    match sign_case:
-        case "none":
-            return None
-        case "unsigned":
-            return False
-        case "signed":
-            return True
-        case "non_boolean_1":
-            return 1
-        case "non_boolean_0":
-            return 0
+    if sign_case == "none":
+        return None
+    elif sign_case == "unsigned":
+        return False
+    elif sign_case == "signed":
+        return True
+    elif sign_case == "non_boolean_1":
+        return 1
+    elif sign_case == "non_boolean_0":
+        return 0
 
 
 def get_summary(char_case):
-    match char_case:
-        case "none":
-            return ""
-        case "normal":
-            return "a blog post about how important bees are to my honey farm"
-        case "over500":
-            return "a blog post about how important bees are to my honey farm" * 10
-        case "non_string":
-            return 1
+    if char_case == "none":
+        return ""
+    elif char_case == "normal":
+        return "a blog post about how important bees are to my honey farm"
+    elif char_case == "over500":
+        return "a blog post about how important bees are to my honey farm" * 10
+    elif char_case == "non_string":
+        return 1
 
 
 def get_section(section_case):
-    match section_case:
-        case "none":
-            return []
-        case "one":
-            return ["Bees and me"]
-        case "multiple":
-            return ["Bees and me", "Honey for you", "Conclusion"]
-        case "non_list":
-            return 1
-        case "non_string_elements":
-            return [1, 2]
+    if section_case == "none":
+        return []
+    elif section_case == "one":
+        return ["Bees and me"]
+    elif section_case == "multiple":
+        return ["Bees and me", "Honey for you", "Conclusion"]
+    elif section_case == "non_list":
+        return 1
+    elif section_case == "non_string_elements":
+        return [1, 2]
 
 
 def expected_chars(char_case):
-    match char_case:
-        case "none":
-            return {
+    if char_case == "none":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                    "summary": ""
-                }
+                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                "summary": ""
             }
-        case "normal":
-            return {
+        }
+    elif char_case == "normal":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                    "summary": "a blog post about how important bees are to my honey farm"
-                }
+                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                "summary": "a blog post about how important bees are to my honey farm"
             }
-        case "over500":
-            return {
+        }
+    elif char_case == "over500":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                    "summary": 'a blog post about how important bees are to '
-                                'my honey farma blog post about how important '
-                                'bees are to my honey farma blog post about '
-                                'how important bees are to my honey farma blog '
-                                'post about how important bees are to my honey '
-                                'farma blog post about how important bees are '
-                                'to my honey farma blog post about how '
-                                'important bees are to my honey farma blog '
-                                'post about how important bees are to my honey '
-                                'farma blog post about how important bees are '
-                                'to my honey farma blog post about how '
-                                'important bees are to my honey farma blog '
-                                'post about how important bees are to my honey '
-                                'farm'
-                }
+                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                "summary": 'a blog post about how important bees are to '
+                            'my honey farma blog post about how important '
+                            'bees are to my honey farma blog post about '
+                            'how important bees are to my honey farma blog '
+                            'post about how important bees are to my honey '
+                            'farma blog post about how important bees are '
+                            'to my honey farma blog post about how '
+                            'important bees are to my honey farma blog '
+                            'post about how important bees are to my honey '
+                            'farma blog post about how important bees are '
+                            'to my honey farma blog post about how '
+                            'important bees are to my honey farma blog '
+                            'post about how important bees are to my honey '
+                            'farm'
             }
-        case "non_string":
-            return {
+        }
+    elif char_case == "non_string":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                    "summary": "1"
-                }
+                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                "summary": "1"
             }
+        }
 
 
 def expected_section(section_case):
-    match section_case:
-        case "none":
-            return {
+    if section_case == "none":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "[]",
-                    "summary": "a blog post about how important bees are to my honey farm"
-                }
+                "sections": "[]",
+                "summary": "a blog post about how important bees are to my honey farm"
             }
-        case "one":
-            return {
+        }
+    elif section_case == "one":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "['Bees and me']",
-                    "summary": "a blog post about how important bees are to my honey farm"
-                }
+                "sections": "['Bees and me']",
+                "summary": "a blog post about how important bees are to my honey farm"
             }
-        case "multiple":
-            return {
+        }
+    elif section_case == "multiple":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
-                    "summary": "a blog post about how important bees are to my honey farm"
-                }
+                "sections": "['Bees and me', 'Honey for you', 'Conclusion']",
+                "summary": "a blog post about how important bees are to my honey farm"
             }
-        case "non_list":
-            return {
+        }
+    elif section_case == "non_list":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "1",
-                    "summary": "a blog post about how important bees are to my honey farm"
-                }
+                "sections": "1",
+                "summary": "a blog post about how important bees are to my honey farm"
             }
-        case "non_string_elements":
-            return {
+        }
+    elif section_case == "non_string_elements":
+        return {
+            "language": "en-US",
+            "preferences": None,
+            "template": "blog-post",
+            "template_params": {
+                "content_length": 1000,
                 "language": "en-US",
-                "preferences": None,
-                "template": "blog-post",
-                "template_params": {
-                    "content_length": 1000,
-                    "language": "en-US",
-                    "sections": "[1, 2]",
-                    "summary": "a blog post about how important bees are to my honey farm"
-                }
+                "sections": "[1, 2]",
+                "summary": "a blog post about how important bees are to my honey farm"
             }
+        }
 
 
 def assert_response(create_content_obj, expected):

--- a/workflow_tests/test_data_source.py
+++ b/workflow_tests/test_data_source.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from dotenv import load_dotenv
 
 import os
 import pytest
@@ -7,6 +8,8 @@ import lilt
 
 from lilt.rest import ApiException
 from pprint import pprint
+
+load_dotenv()
 
 
 configuration = lilt.Configuration(
@@ -35,134 +38,130 @@ translate_file_path = "./workflow_tests/resources"
 
 
 def get_data_source_parameters(case):
-    match case:
-        case "none_src":
-            return {
-                "name": "test-non-src",
-                "srclang": None,
-                "trglang": "en",
-                "srclocale": "US",
-                "trglocale": None
-            }
-        case "none_trg":
-            return {
-                "name": "test-none-trg",
-                "srclang": "en",
-                "trglang": None,
-                "srclocale": "US",
-                "trglocale": None
-            }
-        case "none_both":
-            return {
-                "name": "test-none-both",
-                "srclang": None,
-                "trglang": None,
-                "srclocale": "US",
-                "trglocale": None
-            }
-        case "english":
-            return {
-                "name": "test-english",
-                "srclang": "en",
-                "trglang": "es",
-                "srclocale": "US",
-                "trglocale": None
-            }
-        case "non_english":
-            return {
-                "name": "test-non-english",
-                "srclang": "de",
-                "trglang": "fr",
-                "srclocale": "DE",
-                "trglocale": "FR"
-            }
-        case "source_is_target":
-            return {
-                "name": "test-source-is-target",
-                "srclang": "fr",
-                "trglang": "fr",
-                "srclocale": "FR",
-                "trglocale": "FR"
-            }
-        case "unsupported_languages":
-            return {
-                "name": "test-unsupported-languages",
-                "srclang": "ac",
-                "trglang": "ad",
-                "srclocale": None,
-                "trglocale": None
-            }
-        case "fr_to_en":
-            return {
-                "name": "test-fr-to-en",
-                "srclang": "fr",
-                "trglang": "en",
-                "srclocale": "FR",
-                "trglocale": "US"
-            }
+    if case == "none_src":
+        return {
+            "name": "test-non-src",
+            "srclang": None,
+            "trglang": "en",
+            "srclocale": "US",
+            "trglocale": None
+        }
+    elif case == "none_trg":
+        return {
+            "name": "test-none-trg",
+            "srclang": "en",
+            "trglang": None,
+            "srclocale": "US",
+            "trglocale": None
+        }
+    elif case == "none_both":
+        return {
+            "name": "test-none-both",
+            "srclang": None,
+            "trglang": None,
+            "srclocale": "US",
+            "trglocale": None
+        }
+    elif case == "english":
+        return {
+            "name": "test-english",
+            "srclang": "en",
+            "trglang": "es",
+            "srclocale": "US",
+            "trglocale": None
+        }
+    elif case == "non_english":
+        return {
+            "name": "test-non-english",
+            "srclang": "de",
+            "trglang": "fr",
+            "srclocale": "DE",
+            "trglocale": "FR"
+        }
+    elif case == "source_is_target":
+        return {
+            "name": "test-source-is-target",
+            "srclang": "fr",
+            "trglang": "fr",
+            "srclocale": "FR",
+            "trglocale": "FR"
+        }
+    elif case == "unsupported_languages":
+        return {
+            "name": "test-unsupported-languages",
+            "srclang": "ac",
+            "trglang": "ad",
+            "srclocale": None,
+            "trglocale": None
+        }
+    elif case == "fr_to_en":
+        return {
+            "name": "test-fr-to-en",
+            "srclang": "fr",
+            "trglang": "en",
+            "srclocale": "FR",
+            "trglocale": "US"
+        }
 
 
 def get_tmx_settings(case):
-    match case:
-        case "wrong_data":
-            return {
-                "name": "get_documents.json",
-                "body": f"{translate_file_path}/get_documents.json"
-            }
-
-        case "normal":
-            return {
-                "name": "fr_to_en.tmx",
-                "body": f"{translate_file_path}/test-fr_to_en.tmx"
-            }
+    if case == "wrong_data":
+        return {
+            "name": "get_documents.json",
+            "body": f"{translate_file_path}/get_documents.json"
+        }
+    elif case == "normal":
+        return {
+            "name": "fr_to_en.tmx",
+            "body": f"{translate_file_path}/test-fr_to_en.tmx"
+        }
 
 
 def get_expected_data_source(data_source_case):
-    match data_source_case:
-        case "english":
-            return {
-                "is_processing": None,
-                "name": "test-english",
-                "resources": None,
-                "srclang": "en",
-                "srclocale": "US",
-                "trglang": "es",
-                "trglocale": None,
-                "version": 0
-            }
-        case "non_english":
-            return {
-                "is_processing": None,
-                "name": "test-non-english",
-                "resources": None,
-                "srclang": "de",
-                "srclocale": "DE",
-                "trglang": "fr",
-                "trglocale": "FR",
-                "version": 0
-            }
-        case "source_is_target":
-            return {
-                "is_processing": None,
-                "name": "test-source-is-target",
-                "resources": None,
-                "srclang": "fr",
-                "srclocale": "FR",
-                "trglang": "fr",
-                "trglocale": "FR",
-                "version": 0
-            }
-        case "fr_to_en":
-            return {
-                "is_processing": None,
-                "name": "test-fr-to-en",
-                "resources": None,
-                "srclang": "fr",
-                "srclocale": "FR",
-                "trglang": "en",
-                "trglocale": "US",
-                "version": 0
-            }
+    if data_source_case == "english":
+        return {
+            "is_processing": None,
+            "name": "test-english",
+            "resources": None,
+            "srclang": "en",
+            "srclocale": "US",
+            "trglang": "es",
+            "trglocale": None,
+            "version": 0
+        }
+    elif data_source_case == "non_english":
+        return {
+            "is_processing": None,
+            "name": "test-non-english",
+            "resources": None,
+            "srclang": "de",
+            "srclocale": "DE",
+            "trglang": "fr",
+            "trglocale": "FR",
+            "version": 0
+        }
+    elif data_source_case == "source_is_target":
+        return {
+            "is_processing": None,
+            "name": "test-source-is-target",
+            "resources": None,
+            "srclang": "fr",
+            "srclocale": "FR",
+            "trglang": "fr",
+            "trglocale": "FR",
+            "version": 0
+        }
+    elif data_source_case == "fr_to_en":
+        return {
+            "is_processing": None,
+            "name": "test-fr-to-en",
+            "resources": None,
+            "srclang": "fr",
+            "srclocale": "FR",
+            "trglang": "en",
+            "trglocale": "US",
+            "version": 0
+        }
 
 
 def get_expected_query():

--- a/workflow_tests/test_data_source.py
+++ b/workflow_tests/test_data_source.py
@@ -37,131 +37,135 @@ tmx_file_cases = [
 translate_file_path = "./workflow_tests/resources"
 
 
-def get_data_source_parameters(data_source_case):
-    if data_source_case == "none_src":
-        return {
-            "name": "test-non-src",
-            "srclang": None,
-            "trglang": "en",
-            "srclocale": "US",
-            "trglocale": None
-        }
-    elif data_source_case == "none_trg":
-        return {
-            "name": "test-none-trg",
-            "srclang": "en",
-            "trglang": None,
-            "srclocale": "US",
-            "trglocale": None
-        }
-    elif data_source_case == "none_both":
-        return {
-            "name": "test-none-both",
-            "srclang": None,
-            "trglang": None,
-            "srclocale": "US",
-            "trglocale": None
-        }
-    elif data_source_case == "english":
-        return {
-            "name": "test-english",
-            "srclang": "en",
-            "trglang": "es",
-            "srclocale": "US",
-            "trglocale": None
-        }
-    elif data_source_case == "non_english":
-        return {
-            "name": "test-non-english",
-            "srclang": "de",
-            "trglang": "fr",
-            "srclocale": "DE",
-            "trglocale": "FR"
-        }
-    elif data_source_case == "source_is_target":
-        return {
-            "name": "test-source-is-target",
-            "srclang": "fr",
-            "trglang": "fr",
-            "srclocale": "FR",
-            "trglocale": "FR"
-        }
-    elif data_source_case == "unsupported_languages":
-        return {
-            "name": "test-unsupported-languages",
-            "srclang": "ac",
-            "trglang": "ad",
-            "srclocale": None,
-            "trglocale": None
-        }
-    elif data_source_case == "fr_to_en":
-        return {
-            "name": "test-fr-to-en",
-            "srclang": "fr",
-            "trglang": "en",
-            "srclocale": "FR",
-            "trglocale": "US"
-        }
+def get_data_source_parameters(case):
+    match case:
+        case "none_src":
+            return {
+                "name": "test-non-src",
+                "srclang": None,
+                "trglang": "en",
+                "srclocale": "US",
+                "trglocale": None
+            }
+        case "none_trg":
+            return {
+                "name": "test-none-trg",
+                "srclang": "en",
+                "trglang": None,
+                "srclocale": "US",
+                "trglocale": None
+            }
+        case "none_both":
+            return {
+                "name": "test-none-both",
+                "srclang": None,
+                "trglang": None,
+                "srclocale": "US",
+                "trglocale": None
+            }
+        case "english":
+            return {
+                "name": "test-english",
+                "srclang": "en",
+                "trglang": "es",
+                "srclocale": "US",
+                "trglocale": None
+            }
+        case "non_english":
+            return {
+                "name": "test-non-english",
+                "srclang": "de",
+                "trglang": "fr",
+                "srclocale": "DE",
+                "trglocale": "FR"
+            }
+        case "source_is_target":
+            return {
+                "name": "test-source-is-target",
+                "srclang": "fr",
+                "trglang": "fr",
+                "srclocale": "FR",
+                "trglocale": "FR"
+            }
+        case "unsupported_languages":
+            return {
+                "name": "test-unsupported-languages",
+                "srclang": "ac",
+                "trglang": "ad",
+                "srclocale": None,
+                "trglocale": None
+            }
+        case "fr_to_en":
+            return {
+                "name": "test-fr-to-en",
+                "srclang": "fr",
+                "trglang": "en",
+                "srclocale": "FR",
+                "trglocale": "US"
+            }
 
 
-def get_tmx_settings(tmx_settings_case):
-    if tmx_settings_case == "wrong_data":
-        return {
-            "name": "get_documents.json",
-            "body": f"{translate_file_path}/get_documents.json"
-        }
-    elif tmx_settings_case == "normal":
-        return {
-            "name": "fr_to_en.tmx",
-            "body": f"{translate_file_path}/test-fr_to_en.tmx"
-        }
+def get_tmx_settings(case):
+    match case:
+        case "wrong_data":
+            return {
+                "name": "get_documents.json",
+                "body": f"{translate_file_path}/get_documents.json"
+            }
+
+        case "normal":
+            return {
+                "name": "fr_to_en.tmx",
+                "body": f"{translate_file_path}/test-fr_to_en.tmx"
+            }
 
 
 def get_expected_data_source(data_source_case):
-    if data_source_case == "english":
-        return {
-            "is_processing": None,
-            "name": "test-english",
-            "resources": None,
-            "srclang": "en",
-            "srclocale": "US",
-            "trglang": "es",
-            "trglocale": None,
-            "version": 0
-        }
-    elif data_source_case == "non_english":
-        return {
-            "is_processing": None,
-            "name": "test-non-english",
-            "resources": None,
-            "srclang": "de",
-            "srclocale": "DE",
-            "trglang": "fr",
-            "trglocale": "FR",
-            "version": 0
-        }
-    elif data_source_case == "source_is_target":
-        return {
-            "is_processing": None,
-            "name": "test-source-is-target",
-            "resources": None,
-            "srclang": "fr",
-            "srclocale": "FR",
-            "trglang": "fr",
-            "trglocale": "FR",
-            "version": 0
-        }
-    elif data_source_case == "fr_to_en":
-        return {
-            "is_processing": None,
-            "name": "test-fr-to-en",
-            "resources": None,
-            "srclang": "fr",
-            "srclocale": "FR",
-            "trglang": "en",
-            "trglocale": "US",
-            "version": 0
-        }
+    match data_source_case:
+        case "english":
+            return {
+                "is_processing": None,
+                "name": "test-english",
+                "resources": None,
+                "srclang": "en",
+                "srclocale": "US",
+                "trglang": "es",
+                "trglocale": None,
+                "version": 0
+            }
+        case "non_english":
+            return {
+                "is_processing": None,
+                "name": "test-non-english",
+                "resources": None,
+                "srclang": "de",
+                "srclocale": "DE",
+                "trglang": "fr",
+                "trglocale": "FR",
+                "version": 0
+            }
+        case "source_is_target":
+            return {
+                "is_processing": None,
+                "name": "test-source-is-target",
+                "resources": None,
+                "srclang": "fr",
+                "srclocale": "FR",
+                "trglang": "fr",
+                "trglocale": "FR",
+                "version": 0
+            }
+        case "fr_to_en":
+            return {
+                "is_processing": None,
+                "name": "test-fr-to-en",
+                "resources": None,
+                "srclang": "fr",
+                "srclocale": "FR",
+                "trglang": "en",
+                "trglocale": "US",
+                "version": 0
+            }
 
 
 def get_expected_query():

--- a/workflow_tests/test_data_source.py
+++ b/workflow_tests/test_data_source.py
@@ -37,8 +37,8 @@ tmx_file_cases = [
 translate_file_path = "./workflow_tests/resources"
 
 
-def get_data_source_parameters(case):
-    if case == "none_src":
+def get_data_source_parameters(data_source_case):
+    if data_source_case == "none_src":
         return {
             "name": "test-non-src",
             "srclang": None,
@@ -46,7 +46,7 @@ def get_data_source_parameters(case):
             "srclocale": "US",
             "trglocale": None
         }
-    elif case == "none_trg":
+    elif data_source_case == "none_trg":
         return {
             "name": "test-none-trg",
             "srclang": "en",
@@ -54,7 +54,7 @@ def get_data_source_parameters(case):
             "srclocale": "US",
             "trglocale": None
         }
-    elif case == "none_both":
+    elif data_source_case == "none_both":
         return {
             "name": "test-none-both",
             "srclang": None,
@@ -62,7 +62,7 @@ def get_data_source_parameters(case):
             "srclocale": "US",
             "trglocale": None
         }
-    elif case == "english":
+    elif data_source_case == "english":
         return {
             "name": "test-english",
             "srclang": "en",
@@ -70,7 +70,7 @@ def get_data_source_parameters(case):
             "srclocale": "US",
             "trglocale": None
         }
-    elif case == "non_english":
+    elif data_source_case == "non_english":
         return {
             "name": "test-non-english",
             "srclang": "de",
@@ -78,7 +78,7 @@ def get_data_source_parameters(case):
             "srclocale": "DE",
             "trglocale": "FR"
         }
-    elif case == "source_is_target":
+    elif data_source_case == "source_is_target":
         return {
             "name": "test-source-is-target",
             "srclang": "fr",
@@ -86,7 +86,7 @@ def get_data_source_parameters(case):
             "srclocale": "FR",
             "trglocale": "FR"
         }
-    elif case == "unsupported_languages":
+    elif data_source_case == "unsupported_languages":
         return {
             "name": "test-unsupported-languages",
             "srclang": "ac",
@@ -94,7 +94,7 @@ def get_data_source_parameters(case):
             "srclocale": None,
             "trglocale": None
         }
-    elif case == "fr_to_en":
+    elif data_source_case == "fr_to_en":
         return {
             "name": "test-fr-to-en",
             "srclang": "fr",
@@ -104,13 +104,13 @@ def get_data_source_parameters(case):
         }
 
 
-def get_tmx_settings(case):
-    if case == "wrong_data":
+def get_tmx_settings(tmx_settings_case):
+    if tmx_settings_case == "wrong_data":
         return {
             "name": "get_documents.json",
             "body": f"{translate_file_path}/get_documents.json"
         }
-    elif case == "normal":
+    elif tmx_settings_case == "normal":
         return {
             "name": "fr_to_en.tmx",
             "body": f"{translate_file_path}/test-fr_to_en.tmx"

--- a/workflow_tests/test_instant_translate.py
+++ b/workflow_tests/test_instant_translate.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from dotenv import load_dotenv
 
 import os
 import pytest
@@ -6,6 +7,7 @@ import lilt
 
 from tenacity import retry, stop_after_delay, wait_exponential, retry_if_result, RetryError
 
+load_dotenv()
 
 configuration = lilt.Configuration(
     host=os.environ["API_HOST"],


### PR DESCRIPTION
Tests are running on python 3.8 which do not allow match case syntax, reverting to if else statements