### PR TITLE
feat: add project instructions as a valid parameter

### DIFF
--- a/lilt/models/language_pair.py
+++ b/lilt/models/language_pair.py
@@ -45,7 +45,8 @@ class LanguagePair(object):
         'config_id': 'int',
         'workflow_template_id': 'int',
         'workflow_template_name': 'int',
-        'workflow_stage_assignments': 'list[WorkflowStageAssignment]'
+        'workflow_stage_assignments': 'list[WorkflowStageAssignment]',
+        'instructions': 'str'
     }
 
     attribute_map = {
@@ -61,10 +62,11 @@ class LanguagePair(object):
         'config_id': 'configId',
         'workflow_template_id': 'workflowTemplateId',
         'workflow_template_name': 'workflowTemplateName',
-        'workflow_stage_assignments': 'workflowStageAssignments'
+        'workflow_stage_assignments': 'workflowStageAssignments',
+        'instructions': 'instructions'
     }
 
-    def __init__(self, trg_lang=None, trg_locale=None, due_date=None, memory_id=None, external_model_id=None, pretranslate=None, auto_accept=None, case_sensitive=None, take_match_attribution=None, config_id=None, workflow_template_id=None, workflow_template_name=None, workflow_stage_assignments=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, trg_lang=None, trg_locale=None, due_date=None, memory_id=None, external_model_id=None, pretranslate=None, auto_accept=None, case_sensitive=None, take_match_attribution=None, config_id=None, workflow_template_id=None, workflow_template_name=None, workflow_stage_assignments=None, instructions=None, local_vars_configuration=None):  # noqa: E501
         """LanguagePair - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -83,6 +85,7 @@ class LanguagePair(object):
         self._workflow_template_id = None
         self._workflow_template_name = None
         self._workflow_stage_assignments = None
+        self._instructions = None
         self.discriminator = None
 
         self.trg_lang = trg_lang
@@ -109,6 +112,8 @@ class LanguagePair(object):
             self.workflow_template_name = workflow_template_name
         if workflow_stage_assignments is not None:
             self.workflow_stage_assignments = workflow_stage_assignments
+        if instructions is not None:
+            self.instructions = instructions
 
     @property
     def trg_lang(self):
@@ -410,6 +415,29 @@ class LanguagePair(object):
         """
 
         self._workflow_stage_assignments = workflow_stage_assignments
+
+    @property
+    def instructions(self):
+        """Gets the project instructions of this LanguagePair.  # noqa: E501
+
+        Project instructions for the translation.  # noqa: E501
+
+        :return: The project instructions of this LanguagePair.  # noqa: E501
+        :rtype: str
+        """
+        return self._instructions
+
+    @instructions.setter
+    def instructions(self, instructions):
+        """Sets the project instructions of this LanguagePair.
+
+        Project instructions for the translation.  # noqa: E501
+
+        :param instructions: The project instructions of this LanguagePair.  # noqa: E501
+        :type: str
+        """
+
+        self._instructions = instructions
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/test/test_job_create_parameters.py
+++ b/test/test_job_create_parameters.py
@@ -39,10 +39,10 @@ class TestJobCreateParameters(unittest.TestCase):
             return JobCreateParameters(
                 name = 'My new Job', 
                 due = '2021-10-05T14:48:00.000Z', 
+                src_lang = 'en',
+                src_locale = 'US',
                 language_pairs = [
                     lilt.models.language_pair.LanguagePair(
-                        src_lang = 'en', 
-                        src_locale = 'US', 
                         trg_lang = 'de', 
                         trg_locale = 'DE', 
                         due_date = '2021-10-03T13:43:00.000Z', 
@@ -51,17 +51,18 @@ class TestJobCreateParameters(unittest.TestCase):
                         auto_accept = True, 
                         case_sensitive = True, 
                         take_match_attribution = True, 
-                        config_id = 2332, )
+                        config_id = 2332,
+                        instructions = 'This is a test job' )
                     ], 
                 file_ids = [298, 299]
             )
         else :
             return JobCreateParameters(
                 name = 'My new Job',
+                src_lang = 'en',
+                src_locale = 'US',
                 language_pairs = [
                     lilt.models.language_pair.LanguagePair(
-                        src_lang = 'en', 
-                        src_locale = 'US', 
                         trg_lang = 'de', 
                         trg_locale = 'DE', 
                         due_date = '2021-10-03T13:43:00.000Z', 
@@ -70,7 +71,8 @@ class TestJobCreateParameters(unittest.TestCase):
                         auto_accept = True, 
                         case_sensitive = True, 
                         take_match_attribution = True, 
-                        config_id = 2332, )
+                        config_id = 2332,
+                        instructions = 'This is a test job' )
                     ],
                 file_ids = [298, 299],
         )

--- a/test/test_language_pair.py
+++ b/test/test_language_pair.py
@@ -37,8 +37,6 @@ class TestLanguagePair(unittest.TestCase):
         # model = lilt.models.language_pair.LanguagePair()  # noqa: E501
         if include_optional :
             return LanguagePair(
-                src_lang = 'en', 
-                src_locale = 'US', 
                 trg_lang = 'de', 
                 trg_locale = 'DE', 
                 due_date = '2021-10-03T13:43:00.000Z', 
@@ -47,8 +45,8 @@ class TestLanguagePair(unittest.TestCase):
                 auto_accept = True, 
                 case_sensitive = True, 
                 take_match_attribution = True, 
-                config_id = 2332
-            )
+                config_id = 2332,
+                instructions = 'This is a test job' )
         else :
             return LanguagePair(
                 trg_lang = 'de',


### PR DESCRIPTION
This pull request introduces a new `instructions` field to the `LanguagePair` model in `lilt/models/language_pair.py` and updates related test files to incorporate this change. The most important changes include adding the new field, updating the model's constructor and property methods, and modifying test cases to validate the new functionality.

### Model Updates:

* Added a new `instructions` field to the `LanguagePair` model, including updates to the `swagger_types` and `attribute_map` dictionaries, and the `__init__` method to accept this field. (`lilt/models/language_pair.py`) [[1]](diffhunk://#diff-406178dcc6501fee8baa1708d191cbae9bb70523f07fb86d52752713d302d3d3L48-R49) [[2]](diffhunk://#diff-406178dcc6501fee8baa1708d191cbae9bb70523f07fb86d52752713d302d3d3L64-R69) [[3]](diffhunk://#diff-406178dcc6501fee8baa1708d191cbae9bb70523f07fb86d52752713d302d3d3R88) [[4]](diffhunk://#diff-406178dcc6501fee8baa1708d191cbae9bb70523f07fb86d52752713d302d3d3R115-R116)
* Implemented getter and setter methods for the `instructions` property to handle the new field. (`lilt/models/language_pair.py`)

### Test Updates:

* Updated `test/test_job_create_parameters.py` to include the `instructions` field in the `language_pairs` parameter for both optional and non-optional test cases. [[1]](diffhunk://#diff-56a3225307457f2e69a25700833e970eaaff38de40fa3ddc40922e36526a4564L42-R45) [[2]](diffhunk://#diff-56a3225307457f2e69a25700833e970eaaff38de40fa3ddc40922e36526a4564L54-R65) [[3]](diffhunk://#diff-56a3225307457f2e69a25700833e970eaaff38de40fa3ddc40922e36526a4564L73-R75)
* Updated `test/test_language_pair.py` to include the `instructions` field in the `LanguagePair` test instances. [[1]](diffhunk://#diff-b7a7e8c8c39240066bddb2af6515f3d5fa5c818bca89b8839477042b4348f27dL40-L41) [[2]](diffhunk://#diff-b7a7e8c8c39240066bddb2af6515f3d5fa5c818bca89b8839477042b4348f27dL50-R49)