### PR TITLE
chore: migrate lightweight jobs to gcp-runner-sm

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build:
 
-    runs-on: gcp-runner
+    runs-on: gcp-runner-sm
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Migrate eligible lightweight GitHub Actions jobs from `gcp-runner` to the smaller `gcp-runner-sm` runner pool (4Gi/500m) to optimize resource usage.

## Changes
- Updated `runs-on` label from `gcp-runner` to `gcp-runner-sm` for lightweight jobs (code review, linting, status checks, deploy triggers, etc.)
- Heavy jobs (Docker builds, integration tests, ML workloads) remain on `gcp-runner`

## Test plan
- [ ] Verify migrated jobs complete successfully on `gcp-runner-sm`
- [ ] Monitor for OOM kills or timeout issues

Ref: [ENG-27775](https://lilt.atlassian.net/browse/ENG-27775)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-27775]: https://lilt.atlassian.net/browse/ENG-27775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ